### PR TITLE
Fix jekyll 2.5.3 | Error: wrong number of arguments (1 for 0)

### DIFF
--- a/plugins/static_comments.rb
+++ b/plugins/static_comments.rb
@@ -21,8 +21,8 @@
 class Jekyll::Post
 	alias :to_liquid_without_comments :to_liquid
 	
-	def to_liquid
-		data = to_liquid_without_comments
+	def to_liquid(attrs = nil)
+		data = (attrs.nil? ? to_liquid_without_comments() : to_liquid_without_comments(attrs))
 		data['comments'] = StaticComments::find_for_post(self)
 		data['comment_count'] = data['comments'].length
 		data


### PR DESCRIPTION
The solution has been imported from mpalmer/jekyll-static-comments#14 pull request.
Look at commits by IQAndreas:
- [add additional argument](https://github.com/IQAndreas/jekyll-static-comments/commit/ce7808d9ef7a127bac52de470e6d83cbfaf78457)
- [make argument optional](https://github.com/IQAndreas/jekyll-static-comments/commit/a66590df437e0bd99e12e585e049126e79f81b6d)

Thank you very much,
Tarin
([taringamberini.com migrated to octopress](http://www.taringamberini.com/en/blog/news/migrazione-di-taringamberini-com-en/))
