### PR TITLE
Fix jekyll 2.5.3 | Error: wrong number of arguments (1 for 0)

### DIFF
--- a/static_comments.rb
+++ b/static_comments.rb
@@ -21,8 +21,8 @@
 class Jekyll::Post
 	alias :to_liquid_without_comments :to_liquid
 	
-	def to_liquid
-		data = to_liquid_without_comments
+	def to_liquid(*args)
+		data = to_liquid_without_comments(*args)
 		data['comments'] = StaticComments::find_for_post(self)
 		data['comment_count'] = data['comments'].length
 		data


### PR DESCRIPTION
The solution in pull request by IQAndreas (mpalmer/jekyll-static-comments#14) with commits:
- [add attribute](https://github.com/IQAndreas/jekyll-static-comments/commit/ce7808d9ef7a127bac52de470e6d83cbfaf78457)
- [make attribute optional](https://github.com/IQAndreas/jekyll-static-comments/commit/a66590df437e0bd99e12e585e049126e79f81b6d)

has been [solved in a different way by mpalmer](https://github.com/mpalmer/jekyll-static-comments/commit/4b30bd62d937d2ba6e7f16fc5fe8082abb0d3f1e).

This pull request is simply a "porting" of the mpalmer solution.

Thanks,
Tarin
